### PR TITLE
refactor code

### DIFF
--- a/launch/gz.launch.py
+++ b/launch/gz.launch.py
@@ -11,7 +11,6 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 from launch.event_handlers import OnProcessExit
 from launch_ros.actions import Node, SetParameter
-# from launch_ros.logging import get_logger
 
 
 # logging.basicConfig(level=logging.DEBUG)
@@ -32,18 +31,11 @@ def generate_launch_description():
     # Check if we're told to use sim time
     use_sim_time = LaunchConfiguration('use_sim_time')
     use_ros2_control = LaunchConfiguration('use_ros2_control')
-    use_slam = LaunchConfiguration('use_slam')
 
     rviz = IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(
                     [os.path.join(get_package_share_directory(package_name),'launch','rviz.launch.py')]), 
                     launch_arguments={'use_sim_time': use_sim_time, 'use_ros2_control': use_ros2_control}.items(),
-    )
-
-    joystick = IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(
-                    [os.path.join(get_package_share_directory(package_name),'launch','joystick.launch.py')]), 
-                    launch_arguments={'use_sim_time': use_sim_time}.items()
     )
 
     gazebo_params_file = os.path.join(get_package_share_directory(package_name),'config','gazebo_params.yaml')
@@ -63,75 +55,7 @@ def generate_launch_description():
                                    '-entity', package_name],
                         output='screen',
                         parameters=[{'use_sim_time': use_sim_time}]
-                        # namespace=package_name
                     )
-
-    diff_drive_spawner = Node(
-        package="controller_manager",
-        executable="spawner",
-        name="diff_drive_controller",
-        arguments=["diff_drive_controller"],
-        parameters=[{'use_sim_time': use_sim_time}]
-        # namespace=package_name
-    )
-
-    joint_broad_spawner = Node(
-        package="controller_manager",
-        executable="spawner",
-        name="joint_state_broadcaster",
-        arguments=["joint_state_broadcaster"],
-        parameters=[{'use_sim_time': use_sim_time}]
-        # namespace=package_name
-    )
-
-    controller_params_file = os.path.join(get_package_share_directory(package_name),'config','controllers.yaml')
-    control_node = Node(
-        package="controller_manager",
-        executable="ros2_control_node",
-        parameters=[
-            controller_params_file,
-            {"use_sim_time": use_sim_time},
-            {"tf_buffer_duration": 10.0}],
-        output="both",
-        respawn=True,
-        # namespace=package_name
-    )
-
-    slam_params_file = os.path.join(get_package_share_directory(package_name),'config','mapper_params_online_async.yaml')
-    slam = IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(
-                    [os.path.join(get_package_share_directory(package_name),'launch','online_async_launch.py')]), 
-                    launch_arguments={'use_sim_time': use_sim_time, 'params_file': slam_params_file}.items(),
-                    condition=IfCondition(use_slam)
-    )
-
-    amcl_params_file = os.path.join(get_package_share_directory(package_name),'config','nav2_params.yaml')
-    map_file = os.path.join(get_package_share_directory(package_name),'maps','map_save.yaml')
-    amcl = IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(
-                    [os.path.join(get_package_share_directory(package_name),'launch','localization.launch.py')]), 
-                    launch_arguments={
-                        'use_sim_time': use_sim_time, 
-                        'params_file': amcl_params_file,
-                        'map': map_file
-                    }.items(),
-                    condition=IfCondition(use_slam)
-    )
-
-    navigation = IncludeLaunchDescription(
-                    PythonLaunchDescriptionSource(
-                        [os.path.join(get_package_share_directory(package_name),'launch','navigation.launch.py')]), 
-                        launch_arguments={'use_sim_time': use_sim_time}.items(), 
-                        condition=IfCondition(use_slam)
-    )
-
-    twist_mux_params = os.path.join(get_package_share_directory(package_name),'config','twist_mux.yaml')
-    twist_mux = Node(
-            package="twist_mux",
-            executable="twist_mux",
-            parameters=[twist_mux_params, {'use_sim_time': use_sim_time}],
-            remappings=[('/cmd_vel_out','/diff_drive_controller/cmd_vel_unstamped')]
-        )
 
     return LaunchDescription([
         DeclareLaunchArgument(
@@ -148,14 +72,6 @@ def generate_launch_description():
             description='Use NAV2 toolkit if true'),
         OpaqueFunction(function=log_args),
         rviz,
-        joystick,
-        control_node,  # Move this before gazebo
         gazebo,
         spawn_entity,
-        diff_drive_spawner,
-        joint_broad_spawner,
-        slam,
-        amcl, 
-        navigation,
-        twist_mux,
     ])

--- a/launch/rviz.launch.py
+++ b/launch/rviz.launch.py
@@ -1,33 +1,15 @@
 import os
 
-from launch_ros.actions import Node, SetParameter
+from launch_ros.actions import Node
 from launch import LaunchDescription
-from launch.substitutions import Command, LaunchConfiguration
 from ament_index_python.packages import get_package_share_directory
 
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-
+from launch.actions import DeclareLaunchArgument
 
 
 def generate_launch_description():
     
     package_name = 'mobile_robot'
-    
-    # Check if we're told to use sim time
-    use_sim_time = LaunchConfiguration('use_sim_time')
-    use_ros2_control = LaunchConfiguration('use_ros2_control')
-
-    # Force to use sim time
-    # sim_time = LaunchDescription([
-    #     SetParameter(name='use_sim_time', value=use_sim_time)
-    # ])
-
-    # sim_time = LaunchDescription([
-    #     SetParameter(name='use_ros2_control', value=use_ros2_control)
-    # ])
-
-    xacro_file = get_package_share_directory(package_name) + '/description/robot.urdf.xacro'
 
     rviz_config_file = get_package_share_directory(package_name) + "/config/default.rviz"
     rviz_node = Node(package='rviz2',
@@ -35,48 +17,9 @@ def generate_launch_description():
 					 name='rviz2',
 					 output='log',
 					 arguments=['-d', rviz_config_file],
-                     # namespace=package_name
                 )
 
-	# Robot State Publisher 
-    robot_state_publisher = Node(package='robot_state_publisher',
-								executable='robot_state_publisher',
-								name='robot_state_publisher',
-								output='both',
-								parameters=[{
-                                        'robot_description': Command(['xacro', ' ', xacro_file, ' use_ros2_control:=', use_ros2_control, ' sim_mode:=', use_sim_time])           
-								    }],
-                                # namespace=package_name
-                            )
-
-
-	# # Joint State Publisher 
-    # joint_state_publisher_gui = Node(package='joint_state_publisher_gui',
-	# 								executable='joint_state_publisher_gui',
-	# 								output='screen',
-	# 								name='joint_state_publisher_gui')
-
     if os.environ.get("ULTRALYTICS", "false") == "true":
-        import torch
-        detector_node = Node(
-                package='yolo_detection',
-                executable='detector',
-                name='yolo_node',
-                parameters=[{
-                    'model': 'yolov10m.pt',
-                    'tracker': 'bytetrack.yaml',
-                    'device': 'cuda' if torch.cuda.is_available() else 'cpu',
-                    'enable': True,
-                    'threshold': 0.5,
-                    'image_reliability': 1,
-                    'to_posestamped': True,
-                    'to_pointcloud': True,
-                    'visualize': True,
-                    'stereo_vision': True
-                }],
-                # namespace=package_name
-            )
-        
         viz_node = Node(
                 package='yolo_detection',
                 executable='visualizer',
@@ -86,7 +29,6 @@ def generate_launch_description():
                     'enable': True,
                     'log_image': True
                 }],
-                # namespace=package_name
             )
 
 
@@ -99,11 +41,7 @@ def generate_launch_description():
                 'use_ros2_control',
                 default_value='true',
                 description='Use ros2_control if true'),
-            # sim_time,
-            robot_state_publisher, 
-            # joint_state_publisher_gui, 
             rviz_node,
-            detector_node,
             viz_node
         ])
     else:
@@ -116,8 +54,5 @@ def generate_launch_description():
                 'use_ros2_control',
                 default_value='true',
                 description='Use ros2_control if true'),
-            # sim_time,
-            robot_state_publisher, 
-            # joint_state_publisher_gui, 
             rviz_node,
         ])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Gazebo launch to only start RViz, Gazebo, and entity spawning.
  * Removed joystick, SLAM, navigation, control stack, and related parameter files.
  * Dropped namespace usage for entity spawning.
  * Streamlined RViz launch: removed sim time/ros2_control, robot description/xacro, state publishers, joint state GUI, and ULTRALYTICS detector.
  * RViz now launches only rviz_node; viz_node runs only when ULTRALYTICS=true.

* **Chores**
  * Retained but no longer use the use_slam argument; logging behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->